### PR TITLE
fix: change mysql tag to be able to compose build

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,7 +1,7 @@
 # webpwnized/mutillidae:database
 
 # Start with latest version of MySQL official
-FROM mysql:latest
+FROM mysql:8.0.29-debian
 
 # Set the root password for MySQL server
 ENV MYSQL_ROOT_PASSWORD="mutillidae"


### PR DESCRIPTION
## Issue
I had an issue trying to compose this build: 
since the tag `latest` does not ensure that the build is going to have `apt` installed it will not work.

## Solution
Change the docker database tag version to be one of the latest, but with `debian` installed.