### PR TITLE
fix: add missing user needed for lab #17

### DIFF
--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -60,6 +60,9 @@ RUN apt-get install -y libxml2-dev && docker-php-ext-install xml
 RUN apt-get install -y libonig-dev && docker-php-ext-install mbstring
 RUN apt-get install -y libcurl4-openssl-dev && docker-php-ext-install curl 
 
+# Add missing user for Lab #17
+RUN useradd -M phinius -p 123456
+
 # Install nslookup to enable the command injection vulnerabilities
 RUN apt-get install -y dnsutils
 


### PR DESCRIPTION
## Issue
User need for ldap extraction was missing.

## Solution
Add missing user to apache container