### PR TITLE
Fix: Enforced Debian base image for MySQL database

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,7 +1,7 @@
 # webpwnized/mutillidae:database
 
 # Start with latest version of MySQL official
-FROM mysql:latest
+FROM mysql:debian
 
 # Set the root password for MySQL server
 ENV MYSQL_ROOT_PASSWORD="mutillidae"


### PR DESCRIPTION
Recently MySQL have moved away from using Debian as a base image. This causes errors when building the environment as apt cannot be found. The requested image tag has been changed to `debian` from `latest`.