### PR TITLE
php image does not provide 'ntp' package, use ntpsec instead.

### DIFF
--- a/.build/www/Dockerfile
+++ b/.build/www/Dockerfile
@@ -38,7 +38,7 @@ ARG ENABLE_ERROR_REPORTING=true	# The value can be true or false. The default is
 # Update software packages
 # Install PHP requirements used by Mutillidae II: php-xml, php-mbstring, php-curl, php-mysql, php-ldap
 # Install nslookup to enable the command injection vulnerabilities
-# Install ntp package for Lab #12
+# Install ntpsec package for Lab #12
 # Install ping package for Lab #13
 # Install git
 # Copy the mutillidae project to Apache web files directory
@@ -52,7 +52,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y libonig-dev && docker-php-ext-install mbstring && \
     apt-get install --no-install-recommends -y libcurl4-openssl-dev && docker-php-ext-install curl && \ 
     docker-php-ext-install mysqli && \
-    apt-get install --no-install-recommends -y dnsutils git iputils-ping ntp && \
+    apt-get install --no-install-recommends -y dnsutils git iputils-ping ntpsec && \
     cd /tmp && \
     git clone https://github.com/webpwnized/mutillidae.git mutillidae && \
     cp -r mutillidae/src /var/www/mutillidae && \


### PR DESCRIPTION
It looks like the 'latest' php:apache was migrated to Debian trixie and as of now, it does not offer the ntp package. See: https://github.com/docker-library/php/blob/405703c62b8bd300cb4714c1c4edbc30da85cfc0/8.4/trixie/apache/Dockerfile#L7 I did not test the Lab#12, but ntpsec is the stripped down version and should be sufficient as an ntp client for the challenged to work.


<img width="795" height="427" alt="image" src="https://github.com/user-attachments/assets/d38661b9-9461-4189-b94a-ef372a0d548c" />
